### PR TITLE
Removed invalid reference usage

### DIFF
--- a/AutoSitemap_body.php
+++ b/AutoSitemap_body.php
@@ -120,7 +120,7 @@ class AutoSitemap {
     static function getSQL() {
         global $wgAutoSitemap;
 
-        $dbr =& wfGetDB(DB_REPLICA);
+        $dbr = wfGetDB(DB_REPLICA);
         $page = $dbr->tableName('page');
         $revision = $dbr->tableName('revision');
 
@@ -181,7 +181,7 @@ class AutoSitemap {
         }
 
 
-        $dbr =& wfGetDB(DB_REPLICA);
+        $dbr = wfGetDB(DB_REPLICA);
         $revision = $dbr->tableName('revision');
 
         $sql = "SELECT


### PR DESCRIPTION
This was causing the notice
"PHP Notice:  Only variables should be assigned by reference in /var/www/extensions/AutoSitemap/AutoSitemap_body.php on line 123"