### PR TITLE
Fixed usage of deprecated functions in mediawiki 1.37

### DIFF
--- a/AutoSitemap_body.php
+++ b/AutoSitemap_body.php
@@ -99,11 +99,11 @@ class AutoSitemap {
         $dbr = wfGetDB(DB_REPLICA);
         $res = $dbr->query(self::getSQL());
 
-        $count = $dbr->numRows($res);
+        $count = $res->numRows();
         $pos   = 0;
 
         $data = $wgAutoSitemap["header"];
-        while($row = $dbr->fetchObject($res)) {
+        while($row = $res->fetchObject()) {
             $data .= self::formatResult($server, $row, $pos, $count);
             ++$pos;
         }
@@ -189,12 +189,12 @@ class AutoSitemap {
         FROM $revision WHERE rev_page = $page_id";
 
         $res   = $dbr->query($sql);
-        $count = $dbr->numRows($res);
+        $count = $res->numRows();
 
         if($count < 1) {
             return "daily";
         } else {
-            $item1 = $dbr->fetchObject($res);
+            $item1 = $res->fetchObject();
             $cur = time() ;
             $first = wfTimestamp(TS_UNIX, $item1->creation_timestamp);
 


### PR DESCRIPTION
This does not raise the minimum required version for mediawiki, numRows() and fetchObject() have been part of IResultWrapper for a long time now.

Screenshot of one of my users when updating a page
![image](https://user-images.githubusercontent.com/25136265/183267592-29c345ef-6a3d-4232-b6f2-b4c49b4ce0d4.png)

@dolfinus 