### PR TITLE
Improvements...

### DIFF
--- a/AutoSitemap_body.php
+++ b/AutoSitemap_body.php
@@ -105,18 +105,24 @@ class AutoSitemap {
         $count = $res->numRows();
         $pos   = 0;
 
-        $data = $wgAutoSitemap["header"];
+        self::write($file_handle, $wgAutoSitemap["header"]);
         while($row = $res->fetchObject()) {
-            $data .= self::formatResult($server, $row, $pos, $count);
+            self::write($file_handle, self::formatResult($server, $row, $pos, $count));
             ++$pos;
         }
-        $data .= $wgAutoSitemap["footer"];
+        self::write($file_handle, $wgAutoSitemap["footer"]);
 
-        fwrite($file_handle, utf8_encode($data));
         fclose($file_handle);
         rename($tmp_filename, $filename);
 
         self::notifySitemap();
+    }
+
+    static function write($handle, $data) {
+        $retval = fwrite($handle, utf8_encode($data));
+        if ($retval === FALSE || $retval === 0) {
+            die('Error while writing data.');
+        }
     }
 
     static function getSQL() {

--- a/AutoSitemap_body.php
+++ b/AutoSitemap_body.php
@@ -225,7 +225,7 @@ class AutoSitemap {
         $title = Title::makeTitle($result->namespace, $result->title);
         $url   = $title->getLocalURL();
 
-        $priority = self::getPriority($title, $pos, $count);
+        $priority = sprintf("%01.1f", self::getPriority($title, $pos, $count));
         $last_modification = gmdate("Y-m-d\TH:i:s\Z", wfTimestamp(TS_UNIX, $result->last_modification));
         $freq = self::getChangeFreq($result->id);
 
@@ -236,7 +236,7 @@ class AutoSitemap {
         return '
   <url>
     <loc>'.self::encodeUrl($url).'</loc>
-    <priority>'.str_replace(",", ".", round($priority,1)).'</priority>
+    <priority>'.$priority.'</priority>
     <lastmod>'.$last_modification.'</lastmod>
     <changefreq>'.$freq.'</changefreq>
   </url>';

--- a/AutoSitemap_body.php
+++ b/AutoSitemap_body.php
@@ -119,7 +119,7 @@ class AutoSitemap {
     }
 
     static function write($handle, $data) {
-        $retval = fwrite($handle, utf8_encode($data));
+        $retval = fwrite($handle, $data);
         if ($retval === FALSE || $retval === 0) {
             die('Error while writing data.');
         }

--- a/AutoSitemap_body.php
+++ b/AutoSitemap_body.php
@@ -97,7 +97,11 @@ class AutoSitemap {
         $filename     = $wgAutoSitemap["filename"];
         $tmp_filename = $filename.'.tmp'.bin2hex(random_bytes(16)).'.tmp';
 
-        $file_handle = fopen($tmp_filename, 'w') or die('Cannot write to '.$tmp_filename.'.');
+        $file_handle = fopen($tmp_filename, 'w');
+        if ($file_handle === FALSE) {
+           error_log("Couldn't fopen file: $tmp_filename");
+           return;
+        }
 
         $dbr = wfGetDB(DB_REPLICA);
         $res = $dbr->query(self::getSQL());
@@ -105,14 +109,20 @@ class AutoSitemap {
         $count = $res->numRows();
         $pos   = 0;
 
-        self::write($file_handle, $wgAutoSitemap["header"]);
-        while($row = $res->fetchObject()) {
-            self::write($file_handle, self::formatResult($server, $row, $pos, $count));
-            ++$pos;
+        try {
+            self::write($file_handle, $wgAutoSitemap["header"]);
+            while($row = $res->fetchObject()) {
+                self::write($file_handle, self::formatResult($server, $row, $pos, $count));
+                ++$pos;
+            }
+            self::write($file_handle, $wgAutoSitemap["footer"]);
+        } catch (Exception $e) {
+            error_log("Exception while writing to $tmp_filename: $e");
+            return;
+        } finally {
+            fclose($file_handle);
         }
-        self::write($file_handle, $wgAutoSitemap["footer"]);
 
-        fclose($file_handle);
         rename($tmp_filename, $filename);
 
         self::notifySitemap();
@@ -121,7 +131,7 @@ class AutoSitemap {
     static function write($handle, $data) {
         $retval = fwrite($handle, $data);
         if ($retval === FALSE || $retval === 0) {
-            die('Error while writing data.');
+            throw new Exception("fwrite returned $retval");
         }
     }
 


### PR DESCRIPTION
- Change default priority to 1
- Write output piece by piece instead of building it up in memory
- Always format the priority as a float with one decimal position, i.e. from `0.0` to `1.0`.
- Remove the `utf8_encode()` call, which would only be needed if the data was in `ISO-8859-1` encoding; also, the file shouldn't contain any non-ASCII characters anyway since we encode URLs.