### PR TITLE
Removing the "Notify" feature/option altogether

### DIFF
--- a/AutoSitemap_body.php
+++ b/AutoSitemap_body.php
@@ -167,7 +167,6 @@ class AutoSitemap {
             }
         } else {
             rename($tmp_filename, $filename);
-            self::notifySitemap();
         }
     }
 
@@ -298,18 +297,5 @@ class AutoSitemap {
 
     static function encodeUrl($url) {
         return str_replace(array('(',')'),array('%28','%29'), $url);
-    }
-
-    static public function notifySitemap() {
-        global $wgAutoSitemap;
-        $notify = $wgAutoSitemap["notify"];
-        if(is_array($notify)) {
-            foreach ($notify as $item) {
-                $handle = fopen($item, 'r');
-                if ($handle) {
-                    fclose($handle);
-                }
-            }
-        }
     }
 }

--- a/AutoSitemap_body.php
+++ b/AutoSitemap_body.php
@@ -59,9 +59,6 @@ if (!defined('MEDIAWIKI')) {
 global $wgAutoSitemap, $wgServer, $wgCanonicalServer, $wgScriptPath;
 if (!isset($wgAutoSitemap["filename"]          )) $wgAutoSitemap["filename"]           = "sitemap.xml";
 if (!isset($wgAutoSitemap["server"]            )) $wgAutoSitemap["server"]             = isset($wgCanonicalServer) ? $wgCanonicalServer : $wgServer;
-if (!isset($wgAutoSitemap["notify"]            )) $wgAutoSitemap["notify"]             = [
-                                                                                            'https://www.google.com/webmasters/sitemaps/ping?sitemap='.$wgAutoSitemap["server"].$wgScriptPath.'/'.$wgAutoSitemap["filename"]
-                                                                                         ];
 
 if (!isset($wgAutoSitemap["exclude_namespaces"])) $wgAutoSitemap["exclude_namespaces"] = [
                                                                                             NS_TALK,

--- a/Readme.md
+++ b/Readme.md
@@ -26,15 +26,6 @@ By default all urls in sitemap use $wgCanonicalServer (or $wgServer, if it doesn
 $wgAutoSitemap["server"] = "https://your-site.com";
 ```
 
-### Search engines notification
-You can notify web sites you want about the update of sitemap. Just write all notify urls as array:
-```php
-$wgAutoSitemap["notify"] = [
-    'https://www.google.com/webmasters/sitemaps/ping?sitemap=https://your-site.com/sitemap.xml',
-];
-```
-Sometimes web hoster does not allow the fopen command to call urls (allow_url_fopen=false). If you can't or doesn't want to use notification, set this to empty array by deleting all lines between brackets (`= [];`).
-
 ### Exclude types of pages from sitemap
 You can exclude namespaces or exact pages from including them to sitemap:
 ```php

--- a/extension.json
+++ b/extension.json
@@ -3,7 +3,7 @@
   "author": "Dolfinus",
   "url": "https://www.mediawiki.org/wiki/Extension:AutoSitemap",
   "description": "Creates a XML Sitemap file automatically.",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "license-name": "GPL-3.0+",
   "type": "other",
   "ExtensionMessagesFiles": {


### PR DESCRIPTION
Realistically, no search engine today in the modern world wide web uses sitemap pings or sitemap notification pings anymore, they all use webmaster dashboards with the option to automatically upload sitemap.xml/sitemap.xsl files, and most even have the option to retrieve the file automatically and process it, therefore the "Sitemap ping" feature and others alike it were discontinued for being another relic of the old internet infrastructure of the early 2000's and 2010's.

The last Search Engine to use this feature altogether was Google, and they sunset their usage of it near the end of 2023, even before then search engines like Bing, Yandex, Baidu and even Ask.com had cut the feature altogether long before 2023, therefore I see no reason for this extension to keep this unusable feature at all as it is simply clutter.

You can view Google's Sitemap ping feature sunset notice on their Developer Blog from June of 2023: https://developers.google.com/search/blog/2023/06/sitemaps-lastmod-ping